### PR TITLE
Added code for Kiosk mode

### DIFF
--- a/src/scripts/pagerduty.coffee
+++ b/src/scripts/pagerduty.coffee
@@ -7,6 +7,7 @@
 #   hubot Am I on call - return if I'm currently on call or not
 #   hubot who's on call - return a list of services and who is on call for them
 #   hubot who's on call for <schedule> - return the username of who's on call for any schedule matching <search>
+#   hubot open incident <schedule> <msg> - create a new incident with <msg> and contact the person on call for <schedule>
 #   hubot pager trigger <user> <msg> - create a new incident with <msg> and assign it to <user>
 #   hubot pager trigger <schedule> <msg> - create a new incident with <msg> and assign it the user currently on call for <schedule>
 #   hubot pager incidents - return the current incidents
@@ -46,561 +47,11 @@ pagerDutyUserId        = process.env.HUBOT_PAGERDUTY_USER_ID
 pagerDutyServiceApiKey = process.env.HUBOT_PAGERDUTY_SERVICE_API_KEY
 pagerDutySchedules     = process.env.HUBOT_PAGERDUTY_SCHEDULES
 
+hubotKioskMode         = process.env.HUBOT_KIOSK_MODE
+
 module.exports = (robot) ->
 
-  robot.respond /pager( me)?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-      emailNote = if msg.message.user.pagerdutyEmail
-                    "You've told me your PagerDuty email is #{msg.message.user.pagerdutyEmail}"
-                  else if msg.message.user.email_address
-                    "I'm assuming your PagerDuty email is #{msg.message.user.email_address}. Change it with `#{robot.name} pager me as you@yourdomain.com`"
-      if user
-        msg.send "I found your PagerDuty user #{user.html_url}, #{emailNote}"
-      else
-        msg.send "I couldn't find your user :( #{emailNote}"
-
-    cmds = robot.helpCommands()
-    cmds = (cmd for cmd in cmds when cmd.match(/hubot (pager |who's on call)/))
-    msg.send cmds.join("\n")
-
-  robot.respond /pager(?: me)? as (.*)$/i, (msg) ->
-    email = msg.match[1]
-    msg.message.user.pagerdutyEmail = email
-    msg.send "Okay, I'll remember your PagerDuty email is #{email}"
-
-  robot.respond /pager forget me$/i, (msg) ->
-    msg.message.user.pagerdutyEmail = undefined
-    msg.send "Okay, I've forgotten your PagerDuty email"
-
-  robot.respond /(pager|major)( me)? incident (.*)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    pagerduty.getIncident msg.match[3], (err, incident) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      msg.send formatIncident(incident['incident'])
-
-  robot.respond /(pager|major)( me)? (inc|incidents|sup|problems)$/i, (msg) ->
-    pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      if incidents.length > 0
-        buffer = "Triggered:\n----------\n"
-        for junk, incident of incidents.reverse()
-          if incident.status == 'triggered'
-            buffer = buffer + formatIncident(incident)
-        buffer = buffer + "\nAcknowledged:\n-------------\n"
-        for junk, incident of incidents.reverse()
-          if incident.status == 'acknowledged'
-            buffer = buffer + formatIncident(incident)
-        msg.send buffer
-      else
-        msg.send "No open incidents"
-
-  robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i, (msg) ->
-    msg.reply "Please include a user or schedule to page, like 'hubot pager infrastructure everything is on fire'."
-  robot.respond /(pager|major)( me)? (?:trigger|page) ((["'])([^\4]*?)\4|“([^”]*?)”|‘([^’]*?)’|([\.\w\-]+)) (.+)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    fromUserName = msg.message.user.name
-    query        = msg.match[5] or msg.match[6] or msg.match[7] or msg.match[8]
-    reason       = msg.match[9]
-    description  = "#{reason} - @#{fromUserName}"
-
-    # Figure out who we are
-    campfireUserToPagerDutyUser msg, msg.message.user, false, (triggerdByPagerDutyUser) ->
-      triggerdByPagerDutyUserId = if triggerdByPagerDutyUser?
-                                    triggerdByPagerDutyUser.id
-                                  else if pagerDutyUserId
-                                    pagerDutyUserId
-      unless triggerdByPagerDutyUserId
-        msg.send "Sorry, I can't figure your PagerDuty account, and I don't have my own :( Can you tell me your PagerDuty email with `#{robot.name} pager me as you@yourdomain.com` or make sure you've set the HUBOT_PAGERDUTY_USER_ID environment variable?"
-        return
-
-      # Figure out what we're trying to page
-      reassignmentParametersForUserOrScheduleOrEscalationPolicy msg, query, (results) ->
-        if not (results.assigned_to_user or results.escalation_policy)
-          msg.reply "Couldn't find a user or unique schedule or escalation policy matching #{query} :/"
-          return
-
-        pagerDutyIntegrationAPI msg, "trigger", description, (json) ->
-          query =
-            incident_key: json.incident_key
-
-          msg.reply ":pager: triggered! now assigning it to the right user..."
-
-          setTimeout () ->
-            pagerduty.get "/incidents", query, (err, json) ->
-              if err?
-                robot.emit 'error', err, msg
-                return
-
-              if json?.incidents.length == 0
-                msg.reply "Couldn't find the incident we just created to reassign. Please try again :/"
-              else
-
-              data = null
-              if results.escalation_policy
-                data = {
-                  incidents: json.incidents.map (incident) ->
-                    {
-                      id: incident.id,
-                      type: 'incident_reference',
-                      escalation_policy: {
-                        id: results.escalation_policy,
-                        type: 'escalation_policy_reference'
-                      }
-                    }
-                }
-              else
-                data = {
-                  incidents: json.incidents.map (incident) ->
-                    {
-                      id: incident.id,
-                      type: 'incident_reference',
-                      assignments: [
-                        {
-                          assignee: {
-                            id: results.assigned_to_user,
-                            type: 'user_reference'
-                          }
-                        }
-                      ]
-                    }
-                }
-
-
-                pagerduty.put "/incidents", data , (err, json) ->
-                  if err?
-                    robot.emit 'error', err, msg
-                    return
-
-                  if json?.incidents.length == 1
-                    msg.reply ":pager: assigned to #{results.name}!"
-                  else
-                    msg.reply "Problem reassigning the incident :/"
-          , 10000
-
-  robot.respond /(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i, (msg) ->
-    msg.finish()
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    incidentNumbers = parseIncidentNumbers(msg.match[1])
-
-    # only acknowledge triggered things, since it doesn't make sense to re-acknowledge if it's already in re-acknowledge
-    # if it ever doesn't need acknowledge again, it means it's timed out and has become 'triggered' again anyways
-    updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'acknowledged')
-
-  robot.respond /(pager|major)( me)? ack(nowledge)?(!)?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    force = msg.match[4]?
-
-    pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-        filteredIncidents = if force
-                              incidents # don't filter at all
-                            else
-                              incidentsByUserId(incidents, user.id) # filter by id
-
-        if filteredIncidents.length is 0
-          # nothing assigned to the user, but there were others
-          if incidents.length > 0 and not force
-            msg.send "Nothing assigned to you to acknowledge. Acknowledge someone else's incident with `hubot pager ack <nnn>`"
-          else
-            msg.send "Nothing to acknowledge"
-          return
-
-        incidentNumbers = (incident.incident_number for incident in filteredIncidents)
-
-        # only acknowledge triggered things
-        updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'acknowledged')
-
-  robot.respond /(?:pager|major)(?: me)? res(?:olve)?(?:d)? (.+)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    incidentNumbers = parseIncidentNumbers(msg.match[1])
-
-    # allow resolving of triggered and acknowedlge, since being explicit
-    updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'resolved')
-
-  robot.respond /(pager|major)( me)? res(olve)?(d)?(!)?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    force = msg.match[5]?
-    pagerduty.getIncidents 'acknowledged', (err, incidents) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-        filteredIncidents = if force
-                              incidents # don't filter at all
-                            else
-                              incidentsByUserId(incidents, user.id) # filter by id
-        if filteredIncidents.length is 0
-          # nothing assigned to the user, but there were others
-          if incidents.length > 0 and not force
-            msg.send "Nothing assigned to you to resolve. Resolve someone else's incident with `hubot pager ack <nnn>`"
-          else
-            msg.send "Nothing to resolve"
-          return
-
-        incidentNumbers = (incident.incident_number for incident in filteredIncidents)
-
-        # only resolve things that are acknowledged
-        updateIncidents(msg, incidentNumbers, 'acknowledged', 'resolved')
-
-  robot.respond /(pager|major)( me)? notes (.+)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    incidentId = msg.match[3]
-    pagerduty.get "/incidents/#{incidentId}/notes", {}, (err, json) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      buffer = ""
-      for note in json.notes
-        buffer += "#{note.created_at} #{note.user.summary}: #{note.content}\n"
-      msg.send buffer
-
-  robot.respond /(pager|major)( me)? note ([\d\w]+) (.+)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    incidentId = msg.match[3]
-    content = msg.match[4]
-
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-      userId = user.id
-      return unless userId
-
-      data =
-        note:
-          content: content
-        requester_id: userId
-
-      pagerduty.post "/incidents/#{incidentId}/notes", data, (err, json) ->
-        if err?
-          robot.emit 'error', err, msg
-          return
-
-        if json && json.note
-          msg.send "Got it! Note created: #{json.note.content}"
-        else
-          msg.send "Sorry, I couldn't do it :("
-
-  robot.respond /(pager|major)( me)? schedules( ((["'])([^]*?)\5|(.+)))?$/i, (msg) ->
-    query = {}
-    scheduleName = msg.match[6] or msg.match[7]
-    if scheduleName
-      query['query'] = scheduleName
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    pagerduty.getSchedules query, (err, schedules) ->
-      if err?
-        robot.emit 'error', err, msg
-        return
-
-      buffer = ''
-      if schedules.length > 0
-        for schedule in schedules
-          buffer += "* #{schedule.name} - #{schedule.html_url}\n"
-        msg.send buffer
-      else
-        msg.send 'No schedules found!'
-
-  robot.respond /(pager|major)( me)? (schedule|overrides)( ((["'])([^]*?)\6|([\w\-]+)))?( ([^ ]+)\s*(\d+)?)?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    if msg.match[11]
-      days = msg.match[11]
-    else
-      days = 30
-
-    query = {
-      since: moment().format(),
-      until: moment().add(days, 'days').format(),
-      overflow: 'true'
-    }
-
-    thing = ''
-    if msg.match[3] && msg.match[3].match /overrides/
-      thing = 'overrides'
-      query['editable'] = 'true'
-
-    scheduleName = msg.match[7] or msg.match[8]
-
-    if !scheduleName
-      msg.reply "Please specify a schedule with 'pager #{msg.match[3]} <name>.'' Use 'pager schedules' to list all schedules."
-      return
-
-    if msg.match[10]
-      timezone = msg.match[10]
-    else
-      timezone = 'UTC'
-
-    withScheduleMatching msg, scheduleName, (schedule) ->
-      scheduleId = schedule.id
-      return unless scheduleId
-
-      pagerduty.get "/schedules/#{scheduleId}/#{thing}", query, (err, json) ->
-        if err?
-          robot.emit 'error', err, msg
-          return
-
-        entries = json?.schedule?.final_schedule?.rendered_schedule_entries || json.overrides
-        if entries
-          sortedEntries = entries.sort (a, b) ->
-            moment(a.start).unix() - moment(b.start).unix()
-
-          buffer = ""
-          for entry in sortedEntries
-            startTime = moment(entry.start).tz(timezone).format()
-            endTime   = moment(entry.end).tz(timezone).format()
-            if entry.id
-              buffer += "* (#{entry.id}) #{startTime} - #{endTime} #{entry.user.summary}\n"
-            else
-              buffer += "* #{startTime} - #{endTime} #{entry.user.name}\n"
-          if buffer == ""
-            msg.send "None found!"
-          else
-            msg.send buffer
-        else
-          msg.send "None found!"
-
-  robot.respond /(pager|major)( me)? my schedule( ([^ ]+)\s?(\d+))?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    if msg.match[5]
-      days = msg.match[5]
-    else
-      days = 30
-
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-      userId = user.id
-
-      query = {
-        since: moment().format(),
-        until: moment().add(days, 'days').format(),
-        overflow: 'true'
-      }
-
-      if msg.match[4]
-        timezone = msg.match[4]
-      else
-        timezone = 'UTC'
-
-      pagerduty.getSchedules (err, schedules) ->
-        if err?
-          robot.emit 'error', err, msg
-          return
-
-        if schedules.length > 0
-          renderSchedule = (schedule, cb) ->
-            pagerduty.get "/schedules/#{schedule.id}", query, (err, json) ->
-              if err?
-                cb(err)
-
-              entries = json?.schedule?.final_schedule?.rendered_schedule_entries
-
-              if entries
-                sortedEntries = entries.sort (a, b) ->
-                  moment(a.start).unix() - moment(b.start).unix()
-
-                buffer = ""
-                for entry in sortedEntries
-                  if userId == entry.user.id
-                    startTime = moment(entry.start).tz(timezone).format()
-                    endTime   = moment(entry.end).tz(timezone).format()
-
-                    buffer += "* #{startTime} - #{endTime} #{entry.user.summary} (#{schedule.name})\n"
-                cb(null, buffer)
-
-          async.map schedules, renderSchedule, (err, results) ->
-            if err?
-              robot.emit 'error', err, msg
-              return
-            msg.send results.join("")
-
-        else
-          msg.send 'No schedules found!'
-
-  robot.respond /(pager|major)( me)? (override) ((["'])([^]*?)\5|([\w\-]+)) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    scheduleName = msg.match[6] or msg.match[7]
-
-    if msg.match[11]
-      overrideUser = robot.brain.userForName(msg.match[11])
-
-      unless overrideUser
-        msg.send "Sorry, I don't seem to know who that is. Are you sure they are in chat?"
-        return
-    else
-      overrideUser = msg.message.user
-
-    campfireUserToPagerDutyUser msg, overrideUser, (user) ->
-      userId = user.id
-      return unless userId
-
-      withScheduleMatching msg, scheduleName, (schedule) ->
-        scheduleId = schedule.id
-        return unless scheduleId
-
-        if moment(msg.match[8]).isValid() && moment(msg.match[9]).isValid()
-          start_time = moment(msg.match[8]).format()
-          end_time = moment(msg.match[9]).format()
-
-          override  = {
-            start: start_time,
-            end: end_time,
-            user: {
-              id: userId,
-              type: 'user_reference'
-            }
-          }
-          data = { override: override }
-          pagerduty.post "/schedules/#{scheduleId}/overrides", data, (err, json) ->
-            if err?
-              robot.emit 'error', err, msg
-              return
-
-            if json && json.override
-              start = moment(json.override.start)
-              end = moment(json.override.end)
-              msg.send "Override setup! #{json.override.user.summary} has the pager from #{start.format()} until #{end.format()}"
-            else
-              msg.send "That didn't work. Check Hubot's logs for an error!"
-        else
-          msg.send "Please use a http://momentjs.com/ compatible date!"
-
-  robot.respond /(pager|major)( me)? (overrides?) ((["'])([^]*?)\5|([\w\-]+)) (delete) (.*)$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    scheduleName = msg.match[6] or msg.match[7]
-
-    withScheduleMatching msg, scheduleName, (schedule) ->
-      scheduleId = schedule.id
-      return unless scheduleId
-
-      pagerduty.delete "/schedules/#{scheduleId}/overrides/#{msg.match[9]}", (err, success) ->
-        if success
-          msg.send ":boom:"
-        else
-          msg.send "Something went weird."
-
-  robot.respond /pager( me)? (?!schedules?\b|overrides?\b|my schedule\b)(.+) (\d+)$/i, (msg) ->
-    msg.finish()
-
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-
-      userId = user.id
-      return unless userId
-
-      if !msg.match[2] || msg.match[2] == 'me'
-        msg.reply "Please specify a schedule with 'pager me infrastructure 60'. Use 'pager schedules' to list all schedules."
-        return
-
-      withScheduleMatching msg, msg.match[2], (matchingSchedule) ->
-
-        return unless matchingSchedule.id
-
-        start     = moment().format()
-        minutes   = parseInt msg.match[3]
-        end       = moment().add(minutes, 'minutes').format()
-        override  = {
-          start: start,
-          end: end,
-          user: {
-            id: userId,
-            type: 'user_reference'
-          }
-        }
-        withCurrentOncall msg, matchingSchedule, (old_username, schedule) ->
-          data = { 'override': override }
-          pagerduty.post "/schedules/#{schedule.id}/overrides", data, (err, json) ->
-            if err?
-              robot.emit 'error', err, msg
-              return
-
-            if json.override
-              start = moment(json.override.start)
-              end = moment(json.override.end)
-              msg.send "Rejoice, #{old_username}! #{json.override.user.summary} has the pager on #{schedule.name} until #{end.format()}"
-
-  robot.respond /am i on (call|oncall|on-call)/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
-
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-      userId = user.id
-
-      renderSchedule = (s, cb) ->
-        withCurrentOncallId msg, s, (oncallUserid, oncallUsername, schedule) ->
-          if userId == oncallUserid
-            cb null, "* Yes, you are on call for #{schedule.name} - #{schedule.html_url}"
-          else if oncallUsername == null
-            cb null, "* No, you are NOT on call for #{schedule.name} - #{schedule.html_url}"
-          else
-            cb null, "* No, you are NOT on call for #{schedule.name} (but #{oncallUsername} is) - #{schedule.html_url}"
-
-      if !userId?
-        msg.send "Couldn't figure out the pagerduty user connected to your account."
-      else
-        pagerduty.getSchedules (err, schedules) ->
-          if err?
-            robot.emit 'error', err, msg
-            return
-
-          if schedules.length > 0
-            async.map schedules, renderSchedule, (err, results) ->
-              if err?
-                robot.emit 'error', err, msg
-                return
-              msg.send results.join("\n")
-          else
-            msg.send 'No schedules found!'
-
-  # who is on call?
+  # who is on call? - command always enabled, even in KioskMode
   robot.respond /who(?:’s|'s|s| is|se)? (?:on call|oncall|on-call)(?:\?)?(?: (?:for )?((["'])([^]*?)\2|(.*?))(?:\?|$))?$/i, (msg) ->
     if pagerduty.missingEnvironmentForApi(msg)
       return
@@ -621,7 +72,10 @@ module.exports = (robot) ->
 
         # Ignore schedule if no user assigned to it 
         if (username)
-          messages.push("* #{username} is on call for #{schedule.name} - #{schedule.html_url}")
+          if hubotKioskMode
+            messages.push("* \"#{username}\" is on call for \"#{schedule.name}\"")
+          else
+            messages.push("* \"#{username}\" is on call for \"#{schedule.name}\" - #{schedule.html_url}")
         else
           robot.logger.debug "No user for schedule #{schedule.name}"
 
@@ -649,54 +103,690 @@ module.exports = (robot) ->
         else
           msg.send 'No schedules found!'
 
-  robot.respond /(pager|major)( me)? services$/i, (msg) ->
+  robot.respond /(open )?(incident) ([\w\-]+)$/i, (msg) ->
+    msg.reply "Please include a schedule to page the person on call, like 'hubot open incident \"Infrastructure Support\" everything is on fire'."
+  robot.respond /(open )?(incident) ((["'])([^\4]*?)\4|“([^”]*?)”|‘([^’]*?)’|([\.\w\-]+)) (.+)$/i, (msg) ->
+    msg.finish()
+
     if pagerduty.missingEnvironmentForApi(msg)
       return
+    fromUserName = msg.message.user.name
+    query        = msg.match[5] or msg.match[6] or msg.match[7] or msg.match[8]
+    reason       = msg.match[9]
+    robot.logger.debug "user: #{fromUserName} - query: #{query} - reason: #{reason}"
+    description  = "#{reason} - @#{fromUserName}"
 
-    pagerduty.get "/services", {}, (err, json) ->
-      if err?
-        robot.emit 'error', err, msg
+    # Figure out who we are
+    campfireUserToPagerDutyUser msg, msg.message.user, false, (triggerdByPagerDutyUser) ->
+      triggerdByPagerDutyUserId = if triggerdByPagerDutyUser?
+                                    triggerdByPagerDutyUser.id
+                                  else if pagerDutyUserId
+                                    pagerDutyUserId
+      unless triggerdByPagerDutyUserId
+        msg.send "Sorry, I can't figure your PagerDuty account, and I don't have my own :( Can you tell me your PagerDuty email with `#{robot.name} pager me as you@yourdomain.com` or make sure you've set the HUBOT_PAGERDUTY_USER_ID environment variable?"
         return
 
-      buffer = ''
-      services = json.services
-      if services.length > 0
-        for service in services
-          buffer += "* #{service.id}: #{service.name} (#{service.status}) - #{service.html_url}\n"
-        msg.send buffer
-      else
-        msg.send 'No services found!'
+      # Figure out what we're trying to page
+      reassignmentParametersForUserOrScheduleOrEscalationPolicy msg, query, (results) ->
+        if not (results.assigned_to_user or results.escalation_policy)
+          msg.reply "Couldn't find a user or unique schedule or escalation policy matching #{query} :/"
+          return
 
-  robot.respond /(pager|major)( me)? maintenance (\d+) (.+)$/i, (msg) ->
-    if pagerduty.missingEnvironmentForApi(msg)
-      return
+        pagerDutyIntegrationAPI msg, "trigger", description, (json) ->
+          msg.reply "Incident correctly opened! :pager: Now assigning the person OnCall ..."
 
-    campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
-      requester_id = user.id
-      return unless requester_id
+          setTimeout () ->
+            pagerduty.getIncident json.incident_key, (err, incidents) ->
+              if err?
+                robot.emit 'error', err, msg
+                return
 
-      minutes = msg.match[3]
-      service_ids = msg.match[4].split(' ')
-      start_time = moment().format()
-      end_time = moment().add('minutes', minutes).format()
+              if incidents?.length == 0
+                msg.reply "Failed to assign incident to the person On Call. Please try again :/"
+              else
+                data = {}
+                if results.escalation_policy
+                  data = {
+                    incidents: incidents.map (incident) ->
+                      {
+                        id: incident.id,
+                        type: "incident_reference",
+                        escalation_policy: {
+                          id: results.escalation_policy,
+                          type: "escalation_policy_reference"
+                        }
+                      }
+                  }
+                else
+                  data = {
+                    incidents: incidents.map (incident) ->
+                      {
+                        id: incident.id,
+                        type: "incident_reference",
+                        assignments: [
+                          {
+                            assignee: {
+                              id: results.assigned_to_user,
+                              type: "user_reference"
+                            }
+                          }
+                        ]
+                      }
+                  }
+                pagerduty.put "/incidents", data , (err, json) ->
+                  if err?
+                    robot.emit 'error', err, msg
+                    return
 
-      services = []
-      for service_id in service_ids
-        services.push id: service_id, type: 'service_reference'
+                  if json?.incidents.length == 1
+                    msg.reply ":pager: assigned to #{results.name}!"
+                  else
+                    msg.reply "Problem assigning incident to the person On Call:/"
+          , 10000
 
-      maintenance_window = { start_time, end_time, services }
-      data = { maintenance_window, services }
+  # all the following commands will be disabled in KioskMode
+  if not hubotKioskMode
+    robot.respond /pager( me)?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
 
-      msg.send "Opening maintenance window for: #{service_ids}"
-      pagerduty.post '/maintenance_windows', data, (err, json) ->
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+        emailNote = if msg.message.user.pagerdutyEmail
+                      "You've told me your PagerDuty email is #{msg.message.user.pagerdutyEmail}"
+                    else if msg.message.user.email_address
+                      "I'm assuming your PagerDuty email is #{msg.message.user.email_address}. Change it with `#{robot.name} pager me as you@yourdomain.com`"
+        if user
+          msg.send "I found your PagerDuty user #{user.html_url}, #{emailNote}"
+        else
+          msg.send "I couldn't find your user :( #{emailNote}"
+
+      cmds = robot.helpCommands()
+      cmds = (cmd for cmd in cmds when cmd.match(/hubot (pager |who's on call)/))
+      msg.send cmds.join("\n")
+
+    robot.respond /pager(?: me)? as (.*)$/i, (msg) ->
+      email = msg.match[1]
+      msg.message.user.pagerdutyEmail = email
+      msg.send "Okay, I'll remember your PagerDuty email is #{email}"
+
+    robot.respond /pager forget me$/i, (msg) ->
+      msg.message.user.pagerdutyEmail = undefined
+      msg.send "Okay, I've forgotten your PagerDuty email"
+
+    robot.respond /(pager|major)( me)? incident (.*)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      pagerduty.getIncident msg.match[3], (err, incident) ->
         if err?
           robot.emit 'error', err, msg
           return
 
-        if json && json.maintenance_window
-          msg.send "Maintenance window created! ID: #{json.maintenance_window.id} Ends: #{json.maintenance_window.end_time}"
+        msg.send formatIncident(incident['incident'])
+
+    robot.respond /(pager|major)( me)? (inc|incidents|sup|problems)$/i, (msg) ->
+      pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        if incidents.length > 0
+          buffer = "Triggered:\n----------\n"
+          for junk, incident of incidents.reverse()
+            if incident.status == 'triggered'
+              buffer = buffer + formatIncident(incident)
+          buffer = buffer + "\nAcknowledged:\n-------------\n"
+          for junk, incident of incidents.reverse()
+            if incident.status == 'acknowledged'
+              buffer = buffer + formatIncident(incident)
+          msg.send buffer
         else
-          msg.send "That didn't work. Check Hubot's logs for an error!"
+          msg.send "No open incidents"
+
+    robot.respond /(pager|major)( me)? (?:trigger|page) ([\w\-]+)$/i, (msg) ->
+      msg.reply "Please include a user or schedule to page, like 'hubot pager infrastructure everything is on fire'."
+    robot.respond /(pager|major)( me)? (?:trigger|page) ((["'])([^\4]*?)\4|“([^”]*?)”|‘([^’]*?)’|([\.\w\-]+)) (.+)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      fromUserName = msg.message.user.name
+      query        = msg.match[5] or msg.match[6] or msg.match[7] or msg.match[8]
+      reason       = msg.match[9]
+      description  = "#{reason} - @#{fromUserName}"
+
+      # Figure out who we are
+      campfireUserToPagerDutyUser msg, msg.message.user, false, (triggerdByPagerDutyUser) ->
+        triggerdByPagerDutyUserId = if triggerdByPagerDutyUser?
+                                      triggerdByPagerDutyUser.id
+                                    else if pagerDutyUserId
+                                      pagerDutyUserId
+        unless triggerdByPagerDutyUserId
+          msg.send "Sorry, I can't figure your PagerDuty account, and I don't have my own :( Can you tell me your PagerDuty email with `#{robot.name} pager me as you@yourdomain.com` or make sure you've set the HUBOT_PAGERDUTY_USER_ID environment variable?"
+          return
+
+        # Figure out what we're trying to page
+        reassignmentParametersForUserOrScheduleOrEscalationPolicy msg, query, (results) ->
+          if not (results.assigned_to_user or results.escalation_policy)
+            msg.reply "Couldn't find a user or unique schedule or escalation policy matching #{query} :/"
+            return
+
+          pagerDutyIntegrationAPI msg, "trigger", description, (json) ->
+            query =
+              id: json.id,
+              incident_key: json.incident_key
+
+            msg.reply ":pager: triggered! now assigning it to the right user..."
+
+            setTimeout () ->
+              pagerduty.get "/incidents", query, (err, json) ->
+                if err?
+                  robot.emit 'error', err, msg
+                  return
+
+                if json?.incidents.length == 0
+                  msg.reply "Couldn't find the incident we just created to reassign. Please try again :/"
+                else
+
+                data = null
+                if results.escalation_policy
+                  data = {
+                    incidents: json.incidents.map (incident) ->
+                      {
+                        id: incident.id,
+                        type: 'incident_reference',
+                        escalation_policy: {
+                          id: results.escalation_policy,
+                          type: 'escalation_policy_reference'
+                        }
+                      }
+                  }
+                else
+                  data = {
+                    incidents: json.incidents.map (incident) ->
+                      {
+                        id: incident.id,
+                        type: 'incident_reference',
+                        assignments: [
+                          {
+                            assignee: {
+                              id: results.assigned_to_user,
+                              type: 'user_reference'
+                            }
+                          }
+                        ]
+                      }
+                  }
+
+
+                  pagerduty.put "/incidents", data , (err, json) ->
+                    if err?
+                      robot.emit 'error', err, msg
+                      return
+
+                    if json?.incidents.length == 1
+                      msg.reply ":pager: assigned to #{results.name}!"
+                    else
+                      msg.reply "Problem reassigning the incident :/"
+            , 10000
+
+    robot.respond /(?:pager|major)(?: me)? ack(?:nowledge)? (.+)$/i, (msg) ->
+      msg.finish()
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      incidentNumbers = parseIncidentNumbers(msg.match[1])
+
+      # only acknowledge triggered things, since it doesn't make sense to re-acknowledge if it's already in re-acknowledge
+      # if it ever doesn't need acknowledge again, it means it's timed out and has become 'triggered' again anyways
+      updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'acknowledged')
+
+    robot.respond /(pager|major)( me)? ack(nowledge)?(!)?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      force = msg.match[4]?
+
+      pagerduty.getIncidents 'triggered,acknowledged', (err, incidents) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+          filteredIncidents = if force
+                                incidents # don't filter at all
+                              else
+                                incidentsByUserId(incidents, user.id) # filter by id
+
+          if filteredIncidents.length is 0
+            # nothing assigned to the user, but there were others
+            if incidents.length > 0 and not force
+              msg.send "Nothing assigned to you to acknowledge. Acknowledge someone else's incident with `hubot pager ack <nnn>`"
+            else
+              msg.send "Nothing to acknowledge"
+            return
+
+          incidentNumbers = (incident.incident_number for incident in filteredIncidents)
+
+          # only acknowledge triggered things
+          updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'acknowledged')
+
+    robot.respond /(?:pager|major)(?: me)? res(?:olve)?(?:d)? (.+)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      incidentNumbers = parseIncidentNumbers(msg.match[1])
+
+      # allow resolving of triggered and acknowedlge, since being explicit
+      updateIncidents(msg, incidentNumbers, 'triggered,acknowledged', 'resolved')
+
+    robot.respond /(pager|major)( me)? res(olve)?(d)?(!)?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      force = msg.match[5]?
+      pagerduty.getIncidents 'acknowledged', (err, incidents) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+          filteredIncidents = if force
+                                incidents # don't filter at all
+                              else
+                                incidentsByUserId(incidents, user.id) # filter by id
+          if filteredIncidents.length is 0
+            # nothing assigned to the user, but there were others
+            if incidents.length > 0 and not force
+              msg.send "Nothing assigned to you to resolve. Resolve someone else's incident with `hubot pager ack <nnn>`"
+            else
+              msg.send "Nothing to resolve"
+            return
+
+          incidentNumbers = (incident.incident_number for incident in filteredIncidents)
+
+          # only resolve things that are acknowledged
+          updateIncidents(msg, incidentNumbers, 'acknowledged', 'resolved')
+
+    robot.respond /(pager|major)( me)? notes (.+)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      incidentId = msg.match[3]
+      pagerduty.get "/incidents/#{incidentId}/notes", {}, (err, json) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        buffer = ""
+        for note in json.notes
+          buffer += "#{note.created_at} #{note.user.summary}: #{note.content}\n"
+        msg.send buffer
+
+    robot.respond /(pager|major)( me)? note ([\d\w]+) (.+)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      incidentId = msg.match[3]
+      content = msg.match[4]
+
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+        userId = user.id
+        return unless userId
+
+        data =
+          note:
+            content: content
+          requester_id: userId
+
+        pagerduty.post "/incidents/#{incidentId}/notes", data, (err, json) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+
+          if json && json.note
+            msg.send "Got it! Note created: #{json.note.content}"
+          else
+            msg.send "Sorry, I couldn't do it :("
+
+    robot.respond /(pager|major)( me)? schedules( ((["'])([^]*?)\5|(.+)))?$/i, (msg) ->
+      query = {}
+      scheduleName = msg.match[6] or msg.match[7]
+      if scheduleName
+        query['query'] = scheduleName
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      pagerduty.getSchedules query, (err, schedules) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        buffer = ''
+        if schedules.length > 0
+          for schedule in schedules
+            buffer += "* #{schedule.name} - #{schedule.html_url}\n"
+          msg.send buffer
+        else
+          msg.send 'No schedules found!'
+
+    robot.respond /(pager|major)( me)? (schedule|overrides)( ((["'])([^]*?)\6|([\w\-]+)))?( ([^ ]+)\s*(\d+)?)?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      if msg.match[11]
+        days = msg.match[11]
+      else
+        days = 30
+
+      query = {
+        since: moment().format(),
+        until: moment().add(days, 'days').format(),
+        overflow: 'true'
+      }
+
+      thing = ''
+      if msg.match[3] && msg.match[3].match /overrides/
+        thing = 'overrides'
+        query['editable'] = 'true'
+
+      scheduleName = msg.match[7] or msg.match[8]
+
+      if !scheduleName
+        msg.reply "Please specify a schedule with 'pager #{msg.match[3]} <name>.'' Use 'pager schedules' to list all schedules."
+        return
+
+      if msg.match[10]
+        timezone = msg.match[10]
+      else
+        timezone = 'UTC'
+
+      withScheduleMatching msg, scheduleName, (schedule) ->
+        scheduleId = schedule.id
+        return unless scheduleId
+
+        pagerduty.get "/schedules/#{scheduleId}/#{thing}", query, (err, json) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+
+          entries = json?.schedule?.final_schedule?.rendered_schedule_entries || json.overrides
+          if entries
+            sortedEntries = entries.sort (a, b) ->
+              moment(a.start).unix() - moment(b.start).unix()
+
+            buffer = ""
+            for entry in sortedEntries
+              startTime = moment(entry.start).tz(timezone).format()
+              endTime   = moment(entry.end).tz(timezone).format()
+              if entry.id
+                buffer += "* (#{entry.id}) #{startTime} - #{endTime} #{entry.user.summary}\n"
+              else
+                buffer += "* #{startTime} - #{endTime} #{entry.user.name}\n"
+            if buffer == ""
+              msg.send "None found!"
+            else
+              msg.send buffer
+          else
+            msg.send "None found!"
+
+    robot.respond /(pager|major)( me)? my schedule( ([^ ]+)\s?(\d+))?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      if msg.match[5]
+        days = msg.match[5]
+      else
+        days = 30
+
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+        userId = user.id
+
+        query = {
+          since: moment().format(),
+          until: moment().add(days, 'days').format(),
+          overflow: 'true'
+        }
+
+        if msg.match[4]
+          timezone = msg.match[4]
+        else
+          timezone = 'UTC'
+
+        pagerduty.getSchedules (err, schedules) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+
+          if schedules.length > 0
+            renderSchedule = (schedule, cb) ->
+              pagerduty.get "/schedules/#{schedule.id}", query, (err, json) ->
+                if err?
+                  cb(err)
+
+                entries = json?.schedule?.final_schedule?.rendered_schedule_entries
+
+                if entries
+                  sortedEntries = entries.sort (a, b) ->
+                    moment(a.start).unix() - moment(b.start).unix()
+
+                  buffer = ""
+                  for entry in sortedEntries
+                    if userId == entry.user.id
+                      startTime = moment(entry.start).tz(timezone).format()
+                      endTime   = moment(entry.end).tz(timezone).format()
+
+                      buffer += "* #{startTime} - #{endTime} #{entry.user.summary} (#{schedule.name})\n"
+                  cb(null, buffer)
+
+            async.map schedules, renderSchedule, (err, results) ->
+              if err?
+                robot.emit 'error', err, msg
+                return
+              msg.send results.join("")
+
+          else
+            msg.send 'No schedules found!'
+
+    robot.respond /(pager|major)( me)? (override) ((["'])([^]*?)\5|([\w\-]+)) ([\w\-:\+]+) - ([\w\-:\+]+)( (.*))?$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      scheduleName = msg.match[6] or msg.match[7]
+
+      if msg.match[11]
+        overrideUser = robot.brain.userForName(msg.match[11])
+
+        unless overrideUser
+          msg.send "Sorry, I don't seem to know who that is. Are you sure they are in chat?"
+          return
+      else
+        overrideUser = msg.message.user
+
+      campfireUserToPagerDutyUser msg, overrideUser, (user) ->
+        userId = user.id
+        return unless userId
+
+        withScheduleMatching msg, scheduleName, (schedule) ->
+          scheduleId = schedule.id
+          return unless scheduleId
+
+          if moment(msg.match[8]).isValid() && moment(msg.match[9]).isValid()
+            start_time = moment(msg.match[8]).format()
+            end_time = moment(msg.match[9]).format()
+
+            override  = {
+              start: start_time,
+              end: end_time,
+              user: {
+                id: userId,
+                type: 'user_reference'
+              }
+            }
+            data = { override: override }
+            pagerduty.post "/schedules/#{scheduleId}/overrides", data, (err, json) ->
+              if err?
+                robot.emit 'error', err, msg
+                return
+
+              if json && json.override
+                start = moment(json.override.start)
+                end = moment(json.override.end)
+                msg.send "Override setup! #{json.override.user.summary} has the pager from #{start.format()} until #{end.format()}"
+              else
+                msg.send "That didn't work. Check Hubot's logs for an error!"
+          else
+            msg.send "Please use a http://momentjs.com/ compatible date!"
+
+    robot.respond /(pager|major)( me)? (overrides?) ((["'])([^]*?)\5|([\w\-]+)) (delete) (.*)$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      scheduleName = msg.match[6] or msg.match[7]
+
+      withScheduleMatching msg, scheduleName, (schedule) ->
+        scheduleId = schedule.id
+        return unless scheduleId
+
+        pagerduty.delete "/schedules/#{scheduleId}/overrides/#{msg.match[9]}", (err, success) ->
+          if success
+            msg.send ":boom:"
+          else
+            msg.send "Something went weird."
+
+    robot.respond /pager( me)? (?!schedules?\b|overrides?\b|my schedule\b)(.+) (\d+)$/i, (msg) ->
+      msg.finish()
+
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+
+        userId = user.id
+        return unless userId
+
+        if !msg.match[2] || msg.match[2] == 'me'
+          msg.reply "Please specify a schedule with 'pager me infrastructure 60'. Use 'pager schedules' to list all schedules."
+          return
+
+        withScheduleMatching msg, msg.match[2], (matchingSchedule) ->
+
+          return unless matchingSchedule.id
+
+          start     = moment().format()
+          minutes   = parseInt msg.match[3]
+          end       = moment().add(minutes, 'minutes').format()
+          override  = {
+            start: start,
+            end: end,
+            user: {
+              id: userId,
+              type: 'user_reference'
+            }
+          }
+          withCurrentOncall msg, matchingSchedule, (old_username, schedule) ->
+            data = { 'override': override }
+            pagerduty.post "/schedules/#{schedule.id}/overrides", data, (err, json) ->
+              if err?
+                robot.emit 'error', err, msg
+                return
+
+              if json.override
+                start = moment(json.override.start)
+                end = moment(json.override.end)
+                msg.send "Rejoice, #{old_username}! #{json.override.user.summary} has the pager on #{schedule.name} until #{end.format()}"
+
+    robot.respond /am i on (call|oncall|on-call)/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+        userId = user.id
+
+        renderSchedule = (s, cb) ->
+          withCurrentOncallId msg, s, (oncallUserid, oncallUsername, schedule) ->
+            if userId == oncallUserid
+              cb null, "* Yes, you are on call for #{schedule.name} - #{schedule.html_url}"
+            else if oncallUsername == null
+              cb null, "* No, you are NOT on call for #{schedule.name} - #{schedule.html_url}"
+            else
+              cb null, "* No, you are NOT on call for #{schedule.name} (but #{oncallUsername} is) - #{schedule.html_url}"
+
+        if !userId?
+          msg.send "Couldn't figure out the pagerduty user connected to your account."
+        else
+          pagerduty.getSchedules (err, schedules) ->
+            if err?
+              robot.emit 'error', err, msg
+              return
+
+            if schedules.length > 0
+              async.map schedules, renderSchedule, (err, results) ->
+                if err?
+                  robot.emit 'error', err, msg
+                  return
+                msg.send results.join("\n")
+            else
+              msg.send 'No schedules found!'
+
+    robot.respond /(pager|major)( me)? services$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      pagerduty.get "/services", {}, (err, json) ->
+        if err?
+          robot.emit 'error', err, msg
+          return
+
+        buffer = ''
+        services = json.services
+        if services.length > 0
+          for service in services
+            buffer += "* #{service.id}: #{service.name} (#{service.status}) - #{service.html_url}\n"
+          msg.send buffer
+        else
+          msg.send 'No services found!'
+
+    robot.respond /(pager|major)( me)? maintenance (\d+) (.+)$/i, (msg) ->
+      if pagerduty.missingEnvironmentForApi(msg)
+        return
+
+      campfireUserToPagerDutyUser msg, msg.message.user, (user) ->
+        requester_id = user.id
+        return unless requester_id
+
+        minutes = msg.match[3]
+        service_ids = msg.match[4].split(' ')
+        start_time = moment().format()
+        end_time = moment().add('minutes', minutes).format()
+
+        services = []
+        for service_id in service_ids
+          services.push id: service_id, type: 'service_reference'
+
+        maintenance_window = { start_time, end_time, services }
+        data = { maintenance_window, services }
+
+        msg.send "Opening maintenance window for: #{service_ids}"
+        pagerduty.post '/maintenance_windows', data, (err, json) ->
+          if err?
+            robot.emit 'error', err, msg
+            return
+
+          if json && json.maintenance_window
+            msg.send "Maintenance window created! ID: #{json.maintenance_window.id} Ends: #{json.maintenance_window.end_time}"
+          else
+            msg.send "That didn't work. Check Hubot's logs for an error!"
 
   parseIncidentNumbers = (match) ->
     match.split(/[ ,]+/).map (incidentNumber) ->
@@ -840,7 +930,7 @@ module.exports = (robot) ->
     if (schedule instanceof Array && schedule[0])
       scheduleId = schedule[0].id
     unless scheduleId
-      msg.send "Unable to retrieve the schedule. Use 'pager schedules' to list all schedules."
+      msg.send "Unable to retrieve the schedule (#{scheduleId}). Use 'pager schedules' to list all schedules."
       return
 
     query = {


### PR DESCRIPTION
I'm here proposing a big feature, that I called "Kiosk mode", referring to regular self-service Kiosk you would find in stations and airports.

The use case is to use Hubot-pager-me in a way that is possible to "safely" hand it over to customers so that they can only see what they're allowed to (by the restrictions of Services and Schedules) and by only be able to "open incidents to the person on call" by disabling all the other commands (through the "help module" which already does that).

e.g:
```
>help
CustomerBot help - Displays all of the help commands that this bot knows about.
CustomerBot help <query> - Displays all help commands that match <query>.
CustomerBot open incident <schedule> <msg> - create a new incident with <msg> and contact the person on call for <schedule>
CustomerBot who's on call - return a list of services and who is on call for them
CustomerBot who's on call for <schedule> - return the username of who's on call for any schedule matching 

> who's on call
* "Emanuele Lele Calo" is on call for "Customer Support"

> open incident "Customer Support" everything is on fire, please send help ASAP!
Incident correctly opened! :pager: Now assigning the person OnCall ...
:pager: assigned to Emanuele Lele Calo!
```

Code as it is now is not working cause it needs another fix that I'm also sending in a different PR (in order to be able to mangle "incidents" in a API v2 compatible way).

Open to clarifications if needed.