### PR TITLE
Clean up NPM package by removing development files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+.github
+.husky
+script
+test
+.release-it.json
+CHANGELOG.md


### PR DESCRIPTION
Same as for the `hubot-grafana` package, let's clean out the NPM package by using an `.npmignore`, so we keep:

![image](https://github.com/hubot-archive/hubot-pager-me/assets/583193/2592826b-0699-42a2-b372-5e3c1b410e5e)
