### PR TITLE
Check for empty match on incident lookup

### DIFF
--- a/src/scripts/pagerduty.js
+++ b/src/scripts/pagerduty.js
@@ -92,7 +92,7 @@ module.exports = function (robot) {
     msg.send("Okay, I've forgotten your PagerDuty email");
   });
 
-  robot.respond(/(pager|major)( me)? incident (.*)$/i, function (msg) {
+  robot.respond(/(pager|major)( me)? incident ([a-z0-9]+)$/i, function (msg) {
     msg.finish();
 
     if (pagerduty.missingEnvironmentForApi(msg)) {

--- a/src/scripts/pagerduty.js
+++ b/src/scripts/pagerduty.js
@@ -105,6 +105,12 @@ module.exports = function (robot) {
         return;
       }
 
+      if (!incident || !incident['incident']) {
+        logger.debug(incident);
+        msg.send('No matching incident found for `msg.match[3]`.');
+        return;
+      }
+
       msg.send(formatIncident(incident['incident']));
     });
   });

--- a/test/pager-me-test.js
+++ b/test/pager-me-test.js
@@ -35,7 +35,7 @@ describe('pagerduty', function () {
   });
 
   it('registers a pager incident listener', function () {
-    expect(this.robot.respond).to.have.been.calledWith(/(pager|major)( me)? incident (.*)$/i);
+    expect(this.robot.respond).to.have.been.calledWith(/(pager|major)( me)? incident ([a-z0-9]+)$/i);
   });
 
   it('registers a pager sup listener', function () {


### PR DESCRIPTION
Prior to this PR, a single incident lookup that didn't return a result would cause a `TypeError` when attempting to read its title. This PR addresses that by ensuring that an invalid incident doesn't get that far, instead returning an error message. Additionally, fixes a case where an schedule starting with `Incident` cannot be claimed.

Fixes #223 